### PR TITLE
Better travis/travisbuddy configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,16 @@ os:
 dist: trusty
 sudo: required
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install python3 python3-pip
-  - sudo pip3 install --upgrade pip
-  - sudo pip3 install pylint
+language: python
+python:
+  - 3.6
+
+install:
+  - pip install pylint
 
 script:
-  - ./travis-ci/dircheck.sh
-  - pushd ./travis-ci
-  - ./codecheck.sh
-  - popd
-  - ./travis-ci/validator.sh
+  - ./travis-ci/presubmit.sh
 
 notifications:
   webhooks: https://www.travisbuddy.com
+  on_success: never

--- a/travis-ci/codecheck.sh
+++ b/travis-ci/codecheck.sh
@@ -2,9 +2,6 @@
 # Test code formatting compliance.
 # So far only python3 supported.
 
-TMPFILE=$(mktemp)
-trap "rm -f $TMPFILE" EXIT
-
 # TRAVIS sets TRAVIS_COMMIT_RANGE to the range of commits for the current commit.
 if [[ -z "$TRAVIS_COMMIT_RANGE" ]]; then
   echo >&2 "Note: TRAVIS_COMMIT_RANGE environment variable not set. Defaulting to HEAD HEAD^"
@@ -22,13 +19,6 @@ git diff --diff-filter=AM --name-only $TRAVIS_COMMIT_RANGE | while read fname; d
   # May be possible to use TRAVIS_CI_BUILD instead of .. below.
   ext="${fname##*.}"
   if [[ "$ext" == "py" ]]; then
-    pylint --rcfile=pylint3.rc ../"$fname"
+    pylint --rcfile="travis-ci/pylint3.rc" "$fname"
   fi
 done
-
-# Error out if any files need formatting.
-if grep -q . "$TMPFILE"; then
-  echo "ERROR: The following files need formatting with gofmt -s:"
-  cat $TMPFILE
-  exit 1
-fi

--- a/travis-ci/dircheck.sh
+++ b/travis-ci/dircheck.sh
@@ -52,7 +52,7 @@ fi
 
 if [[ -n "$res" ]]; then
   echo "ERROR: Problems detected in the directory structure:"
-  echo "======================================================================="
+  echo
   echo -ne "$res"
   echo "See https://github.com/osprogramadores/op-desafios#estrutura-de-diret%C3%B3rios for more details"
   exit 1

--- a/travis-ci/presubmit.sh
+++ b/travis-ci/presubmit.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo
+echo "===== Directory Structure check ====="
+echo
+./travis-ci/dircheck.sh
+
+echo
+echo "===== Python code check (if needed) ====="
+echo
+./travis-ci/codecheck.sh
+
+echo
+echo "===== Validator token check ====="
+echo
+./travis-ci/validator.sh


### PR DESCRIPTION
- Don't notify on OK.
- Travis image now uses the "python image" by default (faster)
- All checking scripts called from presubmit.sh (this is a more
  supported travis config and allows travisbuddy to report properly)