### PR TITLE
Desabilita a checagem de nome de variáveis (pylint).

### DIFF
--- a/travis-ci/pylint3.rc
+++ b/travis-ci/pylint3.rc
@@ -134,7 +134,8 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        import-error
+        import-error,
+        invalid-name
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
A configuração default assume que toda variável declarada fora de uma
função é uma constante, e requer maiúsculas, criando confusão.