### PR TITLE
Revert "Add success/fail messages to the PR thread. (#392)"

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -1,5 +1,5 @@
 name: Presubmit tests
-on: [pull_request_target]
+on: [pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -32,21 +32,3 @@ jobs:
       - name: Check code and directory structure
         run: |
           ./ci/presubmit.sh dircheck gocheck pycheck validator
-
-      - name: Tests OK
-        uses: unsplash/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          msg: "👍 Congratulações @${{ github.actor }}! O seu PR passou pelos testes automáticos com sucesso!<p>Próximo passo: um dos administradores fará a revisão do PR e (possivelmente) o merge no repositório oficial. Em caso de problemas, os admins poderão solicitar modificações. Nestes casos, por favor, monitore o seu PR e efetue as modificações assim que possível para evitar demoras na inclusão."
-          check_for_duplicate_msg: false
-        if: ${{ success() }}
-
-      - name: Tests Failed
-        uses: unsplash/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          msg: "🛑 Atenção @${{ github.actor }}: Os testes automáticos detectaram um problema no seu repositório. Por favor, verifique a página de <a href='https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/checks'>Detalhes</a> para identificar o problema. Não é necessário abrir outro PR para corrigir o problema. Apenas corrija o problema no seu cliente, e execute um outro git commit seguido de git push e o PR será atualizado automaticamente com o novo commit."
-          check_for_duplicate_msg: false
-        if: ${{ failure() }}


### PR DESCRIPTION
This does not seem to work with Github Actions because for forked repos
(which we use) github.com runs the actions with the permissions of the
forked repo. If we had more permissions (like adding comments to the
PR), someone could submit a yaml file and mess with the base repo or use
PR comments for spam.

Another option is to use event type = "push_request_target", which
executes everything from the point of view of the base repo. This will
not allow changes in the YAML file to modify the base repo but has the
unfortunate side effect of not pulling the changes from the base repo
(as far as I could tell). What this means in practice is that we can't
tell which files were changed by a PR and can't check files.

This requires more investigation and I'll revert it for now.

This reverts commit 3c4d229cc2c547f2117fd61893f6952490ef3794.