### PR TITLE
Add trailing spaces checks for file contents.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -29,6 +29,10 @@ jobs:
           go get -u golang.org/x/lint/golint
           pip install pylint
 
+      - name: Check directory structure
+        run: |
+          ./ci/dircheck.sh
+
       - name: Check binary files
         run: |
           ./ci/bincheck.sh
@@ -37,13 +41,9 @@ jobs:
         run: |
           ./ci/utfcheck.sh
 
-      - name: Check directory structure
+      - name: Check files containing lines with trailing spaces or tabs
         run: |
-          ./ci/dircheck.sh
-
-      - name: Check Validator code
-        run: |
-          ./ci/validator.sh
+          ./ci/trailing-spaces-check.sh
 
       - name: Check Python code
         run: |
@@ -52,3 +52,8 @@ jobs:
       - name: Check Go code
         run: |
           ./ci/gocheck.sh
+
+      - name: Check Validator code
+        run: |
+          ./ci/validator.sh
+

--- a/ci/trailing-spaces-check.sh
+++ b/ci/trailing-spaces-check.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Exit with an error code if the current commit contains files with
+# lines having spaces or tabs at EOL.
+
+echo '
+======================
+Trailing spaces check
+======================
+'
+
+tmpfile="$(mktemp)"
+# shellcheck disable=SC2064
+trap "rm -f ${tmpfile}" 0
+
+set -o errexit
+set -o nounset
+
+# Only check files added or modified by this commit.
+# TODO: Make this more efficient for large sets of files.
+while read -r fname; do
+  if [[ -s "$fname" ]]; then
+    grep -HPn '[ \t]+$' "$fname" >>"$tmpfile" || true
+  else
+    echo "*** NOTE: Unable to open \"$fname\". This should not happen."
+  fi
+done < "$HOME/changed_files.txt"
+
+if [[ -s "${tmpfile}" ]]; then
+  echo "Found files containing lines with spaces or tabs at end-of-line."
+  echo "Please remove all lines containing only spaces and any extra"
+  echo "spaces or tabs after the last non-blank character in the files"
+  echo "and lines indicated below:"
+  echo
+  cat "${tmpfile}"
+  exit 1
+fi
+
+echo "Test OK: No files with lines containing trailing spaces."
+exit 0


### PR DESCRIPTION
- This should avoid the torrent of files with spaces at eol and
  "blank" lines containing a mix of tabs and spaces.
- Also reorganized order in the presubmit.yaml to something that
  makes more sense.