### PR TITLE
Desconsiderar arquivos removidos no CI

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Compute changed files
         run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
-          curl -s -X GET -G $URL | jq -r '.[] | .filename' > $HOME/changed_files.txt
+          curl -s -X GET -G $URL | jq -r '.[] | select(.status != "removed") | .filename' > $HOME/changed_files.txt
 
       - name: Install & build dependencies
         run: |


### PR DESCRIPTION
Adicionar opção no script para não adicionar os arquivos removidos na lista de arquivos modificados pelo PR.