### PR TITLE
Disable docstring requirements, Use pylint 2.16.2.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           # Binary will be $(go env GOPATH)/bin/golangci-lint
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
-          pip install pylint==2.15.9
+          pip install pylint==2.16.2
           npm install --save-dev eslint-config-standard-with-typescript@23.0.0
 
       - name: Check directory structure

--- a/ci/pylint3.rc
+++ b/ci/pylint3.rc
@@ -54,19 +54,91 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-inline-option,
-        consider-using-with,
+disable=apply-builtin,
+        backtick,
+        bad-inline-option,
+        bad-python3-import,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        cmp-method,
+        coerce-builtin,
+        coerce-method,
+        comprehension-escape,
+        delslice-method,
+        deprecated-itertools-function,
+        deprecated-operator-function,
         deprecated-pragma,
+        deprecated-str-translate-call,
+        deprecated-string-function,
+        deprecated-sys-function,
+        deprecated-types-field,
+        deprecated-urllib-function,
+        dict-items-not-iterating,
+        dict-iter-method,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        dict-view-method,
+        div-method,
+        eq-without-hash,
+        exception-escape,
+        exception-message-attribute,
+        execfile-builtin,
+        file-builtin,
         file-ignored,
+        filter-builtin-not-iterating,
+        getslice-method,
+        hex-method,
+        idiv-method,
         import-error,
+        import-star-module-level,
+        indexing-exception,
+        input-builtin,
+        intern-builtin,
         invalid-name,
+        invalid-str-codec,
+        invalid-unicode-literal,
         locally-disabled,
+        locally-enabled,
+        long-builtin,
+        long-suffix,
+        map-builtin-not-iterating,
+        metaclass-assignment,
+        missing-class-docstring,
         missing-function-docstring,
+        missing-module-docstring,
+        next-method-called,
+        next-method-defined,
+        no-absolute-import,
+        non-ascii-bytes-literal,
+        nonzero-method,
+        oct-method,
+        old-division,
+        old-ne-operator,
+        old-octal-literal,
+        old-raise-syntax,
+        parameter-unpacking,
+        print-statement,
+        raising-string,
+        range-builtin-not-iterating,
         raw-checker-failed,
+        raw_input-builtin,
+        rdiv-method,
+        reduce-builtin,
+        reload-builtin,
+        round-builtin,
+        setslice-method,
+        standarderror-builtin,
         suppressed-message,
-        unspecified-encoding,
+        sys-max-int,
+        unichr-builtin,
+        unicode-builtin,
+        unpacking-in-except,
         useless-suppression,
-
+        using-cmp-argument,
+        xrange-builtin,
+        xreadlines-attribute,
+        zip-builtin-not-iterating
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -132,6 +204,13 @@ max-line-length=100
 
 # Maximum number of lines in a module
 max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.


### PR DESCRIPTION
- Also make the pylint3.rc file match exactly the file used by
  op-web-linter.
