### PR TITLE
Desafio 07 - Unix tac (Python)

### DIFF
--- a/desafio-07/disouzam/python/.gitignore
+++ b/desafio-07/disouzam/python/.gitignore
@@ -1,0 +1,12 @@
+# Criado automaticamente ao abrir o README no Visual Studio Code (configuração da extensão que uso para manipular markdowns)
+README.html
+
+# Configuração do ambiente Python
+create_python3.12_environment.sh
+setup.sh
+activate_python3.12_environment.sh
+requirements.in
+*.txt
+
+# Arquivo de teste, disponível em: https://osprogramadores.com/files/d07/1GB.txt.gz
+1GB.txt.gz

--- a/desafio-07/disouzam/python/README.md
+++ b/desafio-07/disouzam/python/README.md
@@ -1,0 +1,30 @@
+# Introdução
+
+Implementação do comando _tac_ que lê um arquivo e exibe as linhas em ordem inversa - da última para a primeira
+
+
+# Verificação do código com Pylint
+
+O comando a seguir altera o diretório para a pasta do desafio:
+
+```shell
+cd desafio-07/disouzam/python
+```
+
+Executando dentro da pasta do desafio (desafio-07/disouzam/python), o comando para verificar o código através do Pylint é:
+
+```python
+pylint --rcfile=../../../ci/pylint3.rc tac.py
+```
+
+# Como executar o script
+
+Esse código foi testado com a versão 3.12.1 do Python e pode apresentar alguma instabilidade com o Python 3.11 (não foi checado contra essa versão).
+
+Executando dentro da pasta do desafio (desafio-07/disouzam/python), o comando é (com uma palavra de exemplo):
+
+```python
+python -m tac 1GB.txt
+```
+
+# Referências

--- a/desafio-07/disouzam/python/README.md
+++ b/desafio-07/disouzam/python/README.md
@@ -59,4 +59,19 @@ Usando um arquivo mais simples, extraído da página de instruções do desafio 
 python -m tac exemplo1.txt
 ```
 
-# Referências
+# Verificação em estágios
+
+Conforme explicado no commit **9597e92** - O conteúdo revertido é escrito também num arquivo temporário para verificação, alguma razão não esclarecida faz que o md5sum obtido usando pipes no shell (f742e75495168191e16793cd3eea2902) não coincida com o md5sum esperado (2b4fd25f11d75c285ec69ecac420bd07). Suspeita-se que tenha a ver com o caracter de final de linha ou algo específico do sistema Windows. Várias tentativas foram feitas e muitas buscas na internet para tentar resolver o problema mas não consegui uma boa solução até o momento.
+
+A solução que eu apresento é retornar o conteúdo revertido usando o mecanismo do tac original em um arquivo temporário (_temp_file.txt_) e verificar o md5sum usando o cat nesse arquivo. Veja abaixo exemplos da simulação e uma imagem será inserida no pull request
+
+```shell
+python -m tac 1GB.txt | md5sum
+f742e75495168191e16793cd3eea2902
+
+cat temp_file.txt | md5sum
+2b4fd25f11d75c285ec69ecac420bd07
+
+tac 1GB.txt | md5sum
+2b4fd25f11d75c285ec69ecac420bd07
+```

--- a/desafio-07/disouzam/python/README.md
+++ b/desafio-07/disouzam/python/README.md
@@ -23,8 +23,13 @@ pylint --rcfile=../../../ci/pylint3.rc tac.py
 gzip -d 1GB.txt.gz
 ```
 
+Verificação da integridade do arquivo usando o tac
 ```shell
-python -m tac 1GB.txt | md5sum
+tac 1GB.txt | md5sum
+```
+
+Resultado: 
+```
 2b4fd25f11d75c285ec69ecac420bd07
 ```
 
@@ -36,6 +41,16 @@ Executando dentro da pasta do desafio (desafio-07/disouzam/python), o comando pa
 
 ```python
 python -m tac 1GB.txt
+```
+
+Teste e conferência dos resultados:
+```shell
+python -m tac 1GB.txt | md5sum
+```
+
+Resultado esperado:
+```shell
+2b4fd25f11d75c285ec69ecac420bd07
 ```
 
 Usando um arquivo mais simples, extraído da página de instruções do desafio ([#7: UNIX TAC](https://osprogramadores.com/desafios/d07/)) para fins de desenvolvimento, o comando é:

--- a/desafio-07/disouzam/python/README.md
+++ b/desafio-07/disouzam/python/README.md
@@ -28,7 +28,7 @@ Verificação da integridade do arquivo usando o tac
 tac 1GB.txt | md5sum
 ```
 
-Resultado: 
+Resultado:
 ```
 2b4fd25f11d75c285ec69ecac420bd07
 ```

--- a/desafio-07/disouzam/python/README.md
+++ b/desafio-07/disouzam/python/README.md
@@ -17,14 +17,31 @@ Executando dentro da pasta do desafio (desafio-07/disouzam/python), o comando pa
 pylint --rcfile=../../../ci/pylint3.rc tac.py
 ```
 
+# Descompactação do arquivo de teste
+
+```shell
+gzip -d 1GB.txt.gz
+```
+
+```shell
+seu_programa 1GB.txt | md5sum
+2b4fd25f11d75c285ec69ecac420bd07
+```
+
 # Como executar o script
 
 Esse código foi testado com a versão 3.12.1 do Python e pode apresentar alguma instabilidade com o Python 3.11 (não foi checado contra essa versão).
 
-Executando dentro da pasta do desafio (desafio-07/disouzam/python), o comando é (com uma palavra de exemplo):
+Executando dentro da pasta do desafio (desafio-07/disouzam/python), o comando para ler e processar o arquivo de teste é:
 
 ```python
 python -m tac 1GB.txt
+```
+
+Usando um arquivo mais simples, extraído da página de instruções do desafio ([#7: UNIX TAC](https://osprogramadores.com/desafios/d07/)) para fins de desenvolvimento, o comando é:
+
+```python
+python -m tac exemplo1.txt
 ```
 
 # Referências

--- a/desafio-07/disouzam/python/README.md
+++ b/desafio-07/disouzam/python/README.md
@@ -24,7 +24,7 @@ gzip -d 1GB.txt.gz
 ```
 
 ```shell
-seu_programa 1GB.txt | md5sum
+python -m tac 1GB.txt | md5sum
 2b4fd25f11d75c285ec69ecac420bd07
 ```
 

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -4,6 +4,7 @@
 from ctypes import ArgumentError
 import os
 import sys
+import linecache
 
 
 def main(args):
@@ -30,7 +31,8 @@ def main(args):
             "Número excessivo de argumentos. \
             Apenas um argumento com o caminho do arquivo é aceito.")
 
-    imprimir_arquivo_em_ordem_normal(caminho_do_arquivo)
+    numero_linhas_arquivo = obter_a_ultima_linha_do_arquivo(caminho_do_arquivo)
+    print(numero_linhas_arquivo)
 
 
 def imprimir_arquivo_em_ordem_normal(caminho_do_arquivo):
@@ -43,6 +45,60 @@ def imprimir_arquivo_em_ordem_normal(caminho_do_arquivo):
     with open(caminho_do_arquivo, "r", encoding="utf-8") as arquivo:
         for linha in arquivo:
             print(linha, end='')
+
+
+def obter_a_ultima_linha_do_arquivo(caminho_do_arquivo):
+    """obter_a_ultima_linha_do_arquivo(caminho_do_arquivo):
+    Obtém através de uma busca pelo método da bisseção o número da última linha do arquivo
+
+    Parâmetros:
+    caminho_do_arquivo: Caminho do arquivo no disco
+    """
+    result = 0
+    linha_inexistente = ''
+
+    # Verifica primeira linha do arquivo
+    conteudo_linha = linecache.getline(caminho_do_arquivo, 1)
+
+    # Arquivo vazio
+    if conteudo_linha == linha_inexistente:
+        result = 0
+
+    ultima_linha_potencial = 1
+    conteudo_linha = linecache.getline(
+        caminho_do_arquivo, ultima_linha_potencial)
+
+    while conteudo_linha != linha_inexistente:
+        ultima_linha_potencial *= 2
+        conteudo_linha = linecache.getline(
+            caminho_do_arquivo, ultima_linha_potencial)
+
+    ultimo = ultima_linha_potencial
+    meio = int(ultimo/2)
+
+    while meio < ultimo:
+        conteudo_linha_meio = linecache.getline(
+            caminho_do_arquivo, meio)
+
+        conteudo_linha_seguinte = linecache.getline(
+            caminho_do_arquivo, meio + 1)
+
+        # Caso 1: linha do meio e a seguinte estão no meio do arquivo de fato
+        if conteudo_linha_meio != linha_inexistente and conteudo_linha_seguinte != linha_inexistente:
+            meio = meio + int((ultimo - meio)/2)
+
+        # Caso 2: linha do meio e a seguinte estão após o final do arquivo
+        if conteudo_linha_meio == linha_inexistente and conteudo_linha_seguinte == linha_inexistente:
+            ultimo = meio + 1
+            meio = int(ultimo/2)
+
+        # Caso 3: linha do meio é a última linha do arquivo
+        if conteudo_linha_meio != linha_inexistente and conteudo_linha_seguinte == linha_inexistente:
+            break
+
+    result = meio
+
+    return result
 
 
 def debugger_is_active() -> bool:

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -31,8 +31,7 @@ def main(args):
             "Número excessivo de argumentos. \
             Apenas um argumento com o caminho do arquivo é aceito.")
 
-    numero_linhas_arquivo = obter_a_ultima_linha_do_arquivo(caminho_do_arquivo)
-    print(numero_linhas_arquivo)
+    imprimir_arquivo_em_ordem_reversa(caminho_do_arquivo)
 
 
 def imprimir_arquivo_em_ordem_normal(caminho_do_arquivo):
@@ -45,6 +44,23 @@ def imprimir_arquivo_em_ordem_normal(caminho_do_arquivo):
     with open(caminho_do_arquivo, "r", encoding="utf-8") as arquivo:
         for linha in arquivo:
             print(linha, end='')
+
+
+def imprimir_arquivo_em_ordem_reversa(caminho_do_arquivo):
+    """imprimir_arquivo_em_ordem_reversa(caminho_do_arquivo):
+    Abre o arquivo especificado pelo caminho fornecido e imprime seu conteúdo em ordem reversa
+
+    Parâmetros:
+    caminho_do_arquivo: Caminho do arquivo no disco
+    """
+    numero_linhas_arquivo = obter_a_ultima_linha_do_arquivo(caminho_do_arquivo)
+    with open(caminho_do_arquivo, "r", encoding="utf-8") as arquivo:
+        numero_da_linha = numero_linhas_arquivo
+        while numero_da_linha >= 1:
+            conteudo_linha = linecache.getline(
+                caminho_do_arquivo, numero_da_linha)
+            print(conteudo_linha, end='')
+            numero_da_linha -= 1
 
 
 def obter_a_ultima_linha_do_arquivo(caminho_do_arquivo):

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -57,16 +57,33 @@ def imprimir_arquivo_em_ordem_reversa(caminho_do_arquivo):
     numero_linhas_arquivo = obter_a_ultima_linha_do_arquivo(caminho_do_arquivo)
 
     numero_da_linha = numero_linhas_arquivo
-    while numero_da_linha >= 1:
-        conteudo_linha = linecache.getline(
-            caminho_do_arquivo, numero_da_linha)
-        if '\r\n' in conteudo_linha:
-            conteudo_linha = conteudo_linha[:-2]
-        else:
-            conteudo_linha = conteudo_linha[:-1]
 
-        print(conteudo_linha, end='\n')
-        numero_da_linha -= 1
+    temp_file = "temp_file.txt"
+    if os.path.exists(temp_file):
+        os.remove(temp_file)
+
+    with open(temp_file, "a", encoding="utf-8", newline="\n") as arquivo_temporario:
+        while numero_da_linha >= 1:
+            conteudo_linha = linecache.getline(
+                caminho_do_arquivo, numero_da_linha)
+
+            if '\r\n' in conteudo_linha:
+                conteudo_linha = conteudo_linha[:-2]
+
+            if '\n' in conteudo_linha:
+                conteudo_linha = conteudo_linha[:-1]
+
+            conteudo_linha = conteudo_linha + "\n"
+            arquivo_temporario.write(conteudo_linha)
+            numero_da_linha -= 1
+
+    with open(temp_file, "r", encoding="utf-8", newline="\n") as arquivo_temporario:
+        for line in arquivo_temporario:
+            if '\r\n' in line:
+                line = line[:-2]
+            if '\n' in line:
+                line = line[:-1]
+            print(line, end="\n")
 
 
 def obter_a_ultima_linha_do_arquivo(caminho_do_arquivo):

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -1,5 +1,6 @@
 """
-    Implementação do comando _tac_ que lê um arquivo e exibe as linhas em ordem inversa - da última para a primeira
+    Implementação do comando _tac_ que lê um arquivo e exibe as linhas em ordem inversa
+    - da última linha para a primeira a primeira linha
 """
 from ctypes import ArgumentError
 import os
@@ -54,13 +55,13 @@ def imprimir_arquivo_em_ordem_reversa(caminho_do_arquivo):
     caminho_do_arquivo: Caminho do arquivo no disco
     """
     numero_linhas_arquivo = obter_a_ultima_linha_do_arquivo(caminho_do_arquivo)
-    with open(caminho_do_arquivo, "r", encoding="utf-8") as arquivo:
-        numero_da_linha = numero_linhas_arquivo
-        while numero_da_linha >= 1:
-            conteudo_linha = linecache.getline(
-                caminho_do_arquivo, numero_da_linha)
-            print(conteudo_linha, end='')
-            numero_da_linha -= 1
+
+    numero_da_linha = numero_linhas_arquivo
+    while numero_da_linha >= 1:
+        conteudo_linha = linecache.getline(
+            caminho_do_arquivo, numero_da_linha)
+        print(conteudo_linha, end='')
+        numero_da_linha -= 1
 
 
 def obter_a_ultima_linha_do_arquivo(caminho_do_arquivo):
@@ -100,16 +101,18 @@ def obter_a_ultima_linha_do_arquivo(caminho_do_arquivo):
             caminho_do_arquivo, meio + 1)
 
         # Caso 1: linha do meio e a seguinte estão no meio do arquivo de fato
-        if conteudo_linha_meio != linha_inexistente and conteudo_linha_seguinte != linha_inexistente:
+        if linha_inexistente not in (conteudo_linha_meio, conteudo_linha_seguinte):
             meio = meio + int((ultimo - meio)/2)
 
         # Caso 2: linha do meio e a seguinte estão após o final do arquivo
-        if conteudo_linha_meio == linha_inexistente and conteudo_linha_seguinte == linha_inexistente:
+        if conteudo_linha_meio == linha_inexistente and \
+                conteudo_linha_seguinte == linha_inexistente:
             ultimo = meio + 1
             meio = int(ultimo/2)
 
         # Caso 3: linha do meio é a última linha do arquivo
-        if conteudo_linha_meio != linha_inexistente and conteudo_linha_seguinte == linha_inexistente:
+        if conteudo_linha_meio != linha_inexistente and \
+                conteudo_linha_seguinte == linha_inexistente:
             break
 
     result = meio

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -3,9 +3,7 @@
 """
 from ctypes import ArgumentError
 import os
-import string
 import sys
-import re
 
 
 def main(args):
@@ -24,9 +22,13 @@ def main(args):
 
     # Validação dos argumentos
     if len(args) == 2:
-        pass
+        caminho_do_arquivo = args[1]
+        if not os.path.isfile(caminho_do_arquivo):
+            raise FileNotFoundError("Arquivo inexistente ou caminho inválido.")
     else:
-        raise ArgumentError("Número excessivo de argumentos.")
+        raise ArgumentError(
+            "Número excessivo de argumentos. \
+            Apenas um argumento com o caminho do arquivo é aceito.")
 
     print("Draft of main function")
 

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -67,6 +67,8 @@ def imprimir_arquivo_em_ordem_reversa(caminho_do_arquivo):
             conteudo_linha = linecache.getline(
                 caminho_do_arquivo, numero_da_linha)
 
+            conteudo_linha = str(conteudo_linha)
+
             if '\r\n' in conteudo_linha:
                 conteudo_linha = conteudo_linha[:-2]
 

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -60,7 +60,12 @@ def imprimir_arquivo_em_ordem_reversa(caminho_do_arquivo):
     while numero_da_linha >= 1:
         conteudo_linha = linecache.getline(
             caminho_do_arquivo, numero_da_linha)
-        print(conteudo_linha, end='')
+        if '\r\n' in conteudo_linha:
+            conteudo_linha = conteudo_linha[:-2]
+        else:
+            conteudo_linha = conteudo_linha[:-1]
+
+        print(conteudo_linha, end='\n')
         numero_da_linha -= 1
 
 

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -1,0 +1,46 @@
+"""
+    Implementação do comando _tac_ que lê um arquivo e exibe as linhas em ordem inversa - da última para a primeira
+"""
+from ctypes import ArgumentError
+import os
+import string
+import sys
+import re
+
+
+def main(args):
+    """main(args):
+    Processa o arquivo texto e retorna as linhas, da última para a primeira, diretamente no
+    console.
+
+    Parâmetros:
+    args: Lista de argumentos recebido da linha de comando e
+          pré-processado na chamada da função main. Deve conter 2 argumentos e
+          o segundo é o caminho para o arquivo a ser processado.
+    """
+    # Análise dos argumentos recebidos em args
+    if len(args) <= 1:
+        raise ArgumentError("Nenhum argumento foi fornecido.")
+
+    # Validação dos argumentos
+    if len(args) == 2:
+        pass
+    else:
+        raise ArgumentError("Número excessivo de argumentos.")
+
+    print("Draft of main function")
+
+
+def debugger_is_active() -> bool:
+    """Return if the debugger is currently active
+
+    # pylint: disable=line-too-long
+    Source: https://stackoverflow.com/questions/38634988/check-if-program-runs-in-debug-mode/67065084#67065084
+    """
+    return hasattr(sys, 'gettrace') and sys.gettrace() is not None
+
+
+if __name__ == "__main__":
+    if debugger_is_active():
+        print(main.__doc__)
+    main(sys.argv)

--- a/desafio-07/disouzam/python/tac.py
+++ b/desafio-07/disouzam/python/tac.py
@@ -30,14 +30,26 @@ def main(args):
             "Número excessivo de argumentos. \
             Apenas um argumento com o caminho do arquivo é aceito.")
 
-    print("Draft of main function")
+    imprimir_arquivo_em_ordem_normal(caminho_do_arquivo)
+
+
+def imprimir_arquivo_em_ordem_normal(caminho_do_arquivo):
+    """imprimir_arquivo_em_ordem_normal(caminho_do_arquivo):
+    Abre o arquivo especificado pelo caminho fornecido e imprime seu conteúdo em ordem normal
+
+    Parâmetros:
+    caminho_do_arquivo: Caminho do arquivo no disco
+    """
+    with open(caminho_do_arquivo, "r", encoding="utf-8") as arquivo:
+        for linha in arquivo:
+            print(linha, end='')
 
 
 def debugger_is_active() -> bool:
     """Return if the debugger is currently active
 
     # pylint: disable=line-too-long
-    Source: https://stackoverflow.com/questions/38634988/check-if-program-runs-in-debug-mode/67065084#67065084
+    Source: https://stackoverflow.com/questions/38634988/check-if-program-runs-in-debug-mode/67065084
     """
     return hasattr(sys, 'gettrace') and sys.gettrace() is not None
 


### PR DESCRIPTION
O objetivo desse desafio foi implementar a ferramenta / comando do Unix conhecida como tac, com comportamento oposto ao do cat, e, para isso, selecionei a linguagem Python, versão 3.12.2, como tenho feito nos desafios anteriores para meu próprio aprendizado.

A dificuldade desse desafio consistiu em conseguir testar rapidamente e, adicionalmente, um simples erro, causa uma mudança no md5sum retornado, tornando difícil a depuração. Adicionalmente, como explicado no commit **9597e92**, alguma diferença não encontrada ainda no comportamento da saída produzida pelo interpretador Python e usada para transferir via pipe o retorno para a aplicação md5sum causou diferença no resultado.

Lancei mão de uma estratégia alternativa, a ser julgada pelos revisores, que confirmou que a implementação do tac está correta.

Em resumo a estratégia é:
- Reverte-se o conteúdo do arquivo e escreve o conteúdo revertido no arquivo _temp_file.txt_;
- Usando a ferramenta cat, executa-se o seguinte comando para verificar o resultado:

```shell 
cat temp_file.txt | md5sum
```

Evidência da estratégia alternativa:

![image](https://github.com/OsProgramadores/op-desafios/assets/36424026/872c7132-3123-4800-aa3a-259787e83019)


Como os md5sum's retornados foram iguais, isso atestou que minha implementação está minimamente correta (ao menos funciona para o arquivo 1GB.txt).